### PR TITLE
Explicitly note that license is Apache-2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "signed-json"
 version = "0.1.0"
 edition = "2018"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Tools such as `cargo-deny` were having trouble picking this up from the current license text (which it was detecting as "Pixar" bizarrely).

Cargo docs for this field: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields