### PR TITLE
Devon/canonical flag

### DIFF
--- a/benches/json.rs
+++ b/benches/json.rs
@@ -6,12 +6,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, to_vec, Value};
 use test::Bencher;
 
-use signed_json::{json::to_vec_canonical, Canonical, Signed};
+use signed_json::{json::to_vec_canonical, Canonical, CanonicalizationOptions, Signed};
 
 #[bench]
 fn bench_empty_canonical(b: &mut Bencher) {
     let value = json!({});
-    b.iter(|| to_vec_canonical(&value));
+    b.iter(|| to_vec_canonical(&value, CanonicalizationOptions::strict()));
 }
 
 #[bench]
@@ -28,7 +28,7 @@ fn bench_simple_canonical(b: &mut Bencher) {
             "a": "field",
         }
     });
-    b.iter(|| to_vec_canonical(&value));
+    b.iter(|| to_vec_canonical(&value, CanonicalizationOptions::strict()));
 }
 
 #[bench]

--- a/src/canonical.rs
+++ b/src/canonical.rs
@@ -2,10 +2,23 @@ use serde::de::{Deserialize, DeserializeOwned, Deserializer};
 use serde::ser::{Serialize, Serializer};
 use serde_json::error::Error;
 use std::convert::AsRef;
+use std::marker::PhantomData;
 use std::ops::Deref;
 
 use crate::json::canonicalize_deserializer;
 use crate::{to_string_canonical, CanonicalizationOptions};
+
+#[derive(Clone, Debug, Default)]
+pub struct JsonRelaxed;
+#[derive(Clone, Debug, Default)]
+pub struct JsonStrict;
+
+pub trait CanonicalWrapper<V, T>
+where
+    V: Serialize,
+{
+    fn wrap(value: V) -> Result<Canonical<V, T>, Error>;
+}
 
 /// A read only wrapper type for deserializing a JSON value that serializes back
 /// into the original JSON string (modulo being canonicalized).
@@ -40,29 +53,50 @@ use crate::{to_string_canonical, CanonicalizationOptions};
 /// [`Canonical`] stores the serialized canonical JSON and exposes it as
 /// `get_canonical()`.
 #[derive(Clone, Debug)]
-pub struct Canonical<V> {
+pub struct Canonical<V, T = JsonStrict> {
     value: V,
     canonical_json: String,
+
+    canonical_strictness: PhantomData<T>,
 }
 
-impl<V> Canonical<V>
+impl<V> CanonicalWrapper<V, JsonStrict> for Canonical<V, JsonStrict>
 where
     V: Serialize,
 {
     /// Wrap an existing value and use its serialization as the canonical JSON.
-    pub fn wrap(value: V) -> Result<Canonical<V>, Error> {
+    fn wrap(value: V) -> Result<Canonical<V, JsonStrict>, Error> {
         let val: serde_json::Value = serde_json::to_value(&value)?;
 
         let canonical_json = to_string_canonical(&val, CanonicalizationOptions::strict())?;
 
-        Ok(Canonical {
+        Ok(Canonical::<V, JsonStrict> {
             value,
             canonical_json,
+            canonical_strictness: PhantomData,
         })
     }
 }
 
-impl<V> Canonical<V> {
+impl<V> CanonicalWrapper<V, JsonRelaxed> for Canonical<V, JsonRelaxed>
+where
+    V: Serialize,
+{
+    /// Wrap an existing value and use its serialization as the canonical JSON.
+    fn wrap(value: V) -> Result<Canonical<V, JsonRelaxed>, Error> {
+        let val: serde_json::Value = serde_json::to_value(&value)?;
+
+        let canonical_json = to_string_canonical(&val, CanonicalizationOptions::relaxed())?;
+
+        Ok(Canonical::<V, JsonRelaxed> {
+            value,
+            canonical_json,
+            canonical_strictness: PhantomData,
+        })
+    }
+}
+
+impl<V, T> Canonical<V, T> {
     /// Get the stored canonical JSON representation of the wrapped value.
     pub fn get_canonical(&self) -> &str {
         &self.canonical_json
@@ -79,13 +113,13 @@ impl<V> Canonical<V> {
     }
 }
 
-impl<V> AsRef<V> for Canonical<V> {
+impl<V, T> AsRef<V> for Canonical<V, T> {
     fn as_ref(&self) -> &V {
         &self.value
     }
 }
 
-impl<V> Deref for Canonical<V> {
+impl<V, T> Deref for Canonical<V, T> {
     type Target = V;
 
     fn deref(&self) -> &Self::Target {
@@ -93,7 +127,7 @@ impl<V> Deref for Canonical<V> {
     }
 }
 
-impl<V> Serialize for Canonical<V> {
+impl<V, T> Serialize for Canonical<V, T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -105,28 +139,54 @@ impl<V> Serialize for Canonical<V> {
     }
 }
 
-impl<'de, V> Deserialize<'de> for Canonical<V>
+impl<'de, V> Deserialize<'de> for Canonical<V, JsonStrict>
 where
     V: DeserializeOwned,
 {
-    fn deserialize<D>(deserializer: D) -> Result<Canonical<V>, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Canonical<V, JsonStrict>, D::Error>
     where
         D: Deserializer<'de>,
     {
         let canonical_json =
-            canonicalize_deserializer(deserializer).map_err(serde::de::Error::custom)?;
+            canonicalize_deserializer(deserializer, CanonicalizationOptions::strict())
+                .map_err(serde::de::Error::custom)?;
 
         let value = serde_json::from_str(&canonical_json).map_err(serde::de::Error::custom)?;
 
         Ok(Canonical {
             value,
             canonical_json,
+            canonical_strictness: PhantomData,
+        })
+    }
+}
+
+impl<'de, V> Deserialize<'de> for Canonical<V, JsonRelaxed>
+where
+    V: DeserializeOwned,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Canonical<V, JsonRelaxed>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let canonical_json =
+            canonicalize_deserializer(deserializer, CanonicalizationOptions::relaxed())
+                .map_err(serde::de::Error::custom)?;
+
+        let value = serde_json::from_str(&canonical_json).map_err(serde::de::Error::custom)?;
+
+        Ok(Canonical {
+            value,
+            canonical_json,
+            canonical_strictness: PhantomData,
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::i64;
+
     use crate::CanonicalizationOptions;
 
     use super::*;
@@ -134,7 +194,7 @@ mod tests {
 
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     struct A {
-        a: u32,
+        a: i64,
     }
 
     #[test]
@@ -142,15 +202,41 @@ mod tests {
         let c: Canonical<A> = serde_json::from_str(r#"{"a": 2}"#).unwrap();
 
         assert_eq!(c.as_ref(), &A { a: 2 });
+
+        let _c = serde_json::from_str::<Canonical<A>>(r#"{"a": 9223372036854775807}"#).unwrap_err();
+
+        let c: Canonical<A, JsonRelaxed> =
+            serde_json::from_str(r#"{"a": 9223372036854775807}"#).unwrap();
+
+        assert_eq!(
+            c.as_ref(),
+            &A {
+                a: 9223372036854775807
+            }
+        );
     }
 
     #[test]
     fn test_serialize() {
-        let c = Canonical::wrap(A { a: 2 }).unwrap();
+        let c = Canonical::<A>::wrap(A { a: 2 }).unwrap();
 
         let s = to_string_canonical(&c, CanonicalizationOptions::strict()).unwrap();
 
         assert_eq!(&s, r#"{"a":2}"#);
+
+        let _c = Canonical::<A>::wrap(A {
+            a: 9223372036854775807,
+        })
+        .unwrap_err();
+
+        let c = Canonical::<A, JsonRelaxed>::wrap(A {
+            a: 9223372036854775807,
+        })
+        .unwrap();
+
+        let s = to_string_canonical(&c, CanonicalizationOptions::relaxed()).unwrap();
+
+        assert_eq!(&s, r#"{"a":9223372036854775807}"#);
     }
 
     #[test]

--- a/src/canonical.rs
+++ b/src/canonical.rs
@@ -5,7 +5,7 @@ use std::convert::AsRef;
 use std::ops::Deref;
 
 use crate::json::canonicalize_deserializer;
-use crate::to_string_canonical;
+use crate::{to_string_canonical, CanonicalizationOptions};
 
 /// A read only wrapper type for deserializing a JSON value that serializes back
 /// into the original JSON string (modulo being canonicalized).
@@ -53,7 +53,7 @@ where
     pub fn wrap(value: V) -> Result<Canonical<V>, Error> {
         let val: serde_json::Value = serde_json::to_value(&value)?;
 
-        let canonical_json = to_string_canonical(&val)?;
+        let canonical_json = to_string_canonical(&val, CanonicalizationOptions::strict())?;
 
         Ok(Canonical {
             value,
@@ -127,6 +127,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::CanonicalizationOptions;
+
     use super::*;
     use serde::{Deserialize, Serialize};
 
@@ -146,7 +148,7 @@ mod tests {
     fn test_serialize() {
         let c = Canonical::wrap(A { a: 2 }).unwrap();
 
-        let s = to_string_canonical(&c).unwrap();
+        let s = to_string_canonical(&c, CanonicalizationOptions::strict()).unwrap();
 
         assert_eq!(&s, r#"{"a":2}"#);
     }
@@ -156,7 +158,7 @@ mod tests {
         let c: Canonical<A> = serde_json::from_str(r#"{"a": 2, "b": 3}"#).unwrap();
         assert_eq!(c.as_ref(), &A { a: 2 });
 
-        let s = to_string_canonical(&c).unwrap();
+        let s = to_string_canonical(&c, CanonicalizationOptions::strict()).unwrap();
 
         assert_eq!(&s, r#"{"a":2,"b":3}"#);
     }

--- a/src/canonical.rs
+++ b/src/canonical.rs
@@ -8,15 +8,20 @@ use std::ops::Deref;
 use crate::json::canonicalize_deserializer;
 use crate::{to_string_canonical, CanonicalizationOptions};
 
+/// Marker type that relaxes the canonical JSON rules to accomodate room versions v5 or older.
 #[derive(Clone, Debug, Default)]
 pub struct JsonRelaxed;
+
+/// Marker type that enforces all canonical JSON rules to accomodate room versions v6 or newer.
 #[derive(Clone, Debug, Default)]
 pub struct JsonStrict;
 
+/// API to wrap an existing JSON value with it's canonical form.
 pub trait CanonicalWrapper<V, T>
 where
     V: Serialize,
 {
+    /// Wrap an existing value and use its serialization as the canonical JSON.
     fn wrap(value: V) -> Result<Canonical<V, T>, Error>;
 }
 
@@ -64,7 +69,6 @@ impl<V> CanonicalWrapper<V, JsonStrict> for Canonical<V, JsonStrict>
 where
     V: Serialize,
 {
-    /// Wrap an existing value and use its serialization as the canonical JSON.
     fn wrap(value: V) -> Result<Canonical<V, JsonStrict>, Error> {
         let val: serde_json::Value = serde_json::to_value(&value)?;
 
@@ -82,7 +86,6 @@ impl<V> CanonicalWrapper<V, JsonRelaxed> for Canonical<V, JsonRelaxed>
 where
     V: Serialize,
 {
-    /// Wrap an existing value and use its serialization as the canonical JSON.
     fn wrap(value: V) -> Result<Canonical<V, JsonRelaxed>, Error> {
         let val: serde_json::Value = serde_json::to_value(&value)?;
 

--- a/src/json.rs
+++ b/src/json.rs
@@ -109,12 +109,15 @@ where
 }
 
 /// Transcode the deserializer to canonical JSON.
-pub fn canonicalize_deserializer<'de, D>(deserializer: D) -> Result<String, serde_json::Error>
+pub fn canonicalize_deserializer<'de, D>(
+    deserializer: D,
+    options: CanonicalizationOptions,
+) -> Result<String, serde_json::Error>
 where
     D: Deserializer<'de>,
 {
     let mut vec = Vec::new();
-    let mut serializer = CanonicalSerializer::new(&mut vec, CanonicalizationOptions::strict());
+    let mut serializer = CanonicalSerializer::new(&mut vec, options);
     serde_transcode::transcode(deserializer, &mut serializer)?;
 
     let json_string = String::from_utf8(vec).expect("valid utf8");
@@ -123,10 +126,13 @@ where
 }
 
 /// Convert the given JSON string to canonical JSON.
-pub fn canonicalize_string(value: &str) -> Result<String, serde_json::Error> {
+pub fn canonicalize_string(
+    value: &str,
+    options: CanonicalizationOptions,
+) -> Result<String, serde_json::Error> {
     let mut deserializer = serde_json::Deserializer::from_str(value);
 
-    canonicalize_deserializer(&mut deserializer)
+    canonicalize_deserializer(&mut deserializer, options)
 }
 
 /// A helper function that asserts that an integer is in the valid range.

--- a/src/json.rs
+++ b/src/json.rs
@@ -8,7 +8,7 @@ use std::{
     collections::BTreeMap,
     convert::TryFrom,
     io::{self, Write},
-    sync::atomic::AtomicBool,
+    sync::atomic::{AtomicBool, Ordering},
 };
 
 use serde::{ser::SerializeMap, Deserializer};
@@ -109,6 +109,10 @@ fn assert_integer_in_range<I>(v: I) -> Result<(), serde_json::Error>
 where
     i64: TryFrom<I>,
 {
+    if !ENFORCE_INT_RANGE.load(Ordering::Relaxed) {
+        return Ok(());
+    }
+
     let res = i64::try_from(v);
     match res {
         Ok(MIN_VALID_INTEGER..=MAX_VALID_INTEGER) => Ok(()),
@@ -239,17 +243,13 @@ where
     }
 
     fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
-        if ENFORCE_INT_RANGE.load(std::sync::atomic::Ordering::Relaxed) {
-            assert_integer_in_range(v)?;
-        }
+        assert_integer_in_range(v)?;
 
         self.inner.serialize_i64(v)
     }
 
     fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
-        if ENFORCE_INT_RANGE.load(std::sync::atomic::Ordering::Relaxed) {
-            assert_integer_in_range(v)?;
-        }
+        assert_integer_in_range(v)?;
 
         self.inner.serialize_i128(v)
     }
@@ -271,17 +271,13 @@ where
     }
 
     fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
-        if ENFORCE_INT_RANGE.load(std::sync::atomic::Ordering::Relaxed) {
-            assert_integer_in_range(v)?;
-        }
+        assert_integer_in_range(v)?;
 
         self.inner.serialize_u64(v)
     }
 
     fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
-        if ENFORCE_INT_RANGE.load(std::sync::atomic::Ordering::Relaxed) {
-            assert_integer_in_range(v)?;
-        }
+        assert_integer_in_range(v)?;
 
         self.inner.serialize_u128(v)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use std::convert::TryInto;
 use anyhow::Error;
 pub use canonical::Canonical;
 #[doc(inline)]
-pub use json::{to_string_canonical, to_vec_canonical};
+pub use json::{to_string_canonical, to_vec_canonical, ENFORCE_INT_RANGE};
 #[doc(inline)]
 #[cfg(feature = "signed")]
 pub use signed::Signed;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use std::convert::TryInto;
 use anyhow::Error;
 pub use canonical::Canonical;
 #[doc(inline)]
-pub use json::{to_string_canonical, to_vec_canonical, ENFORCE_INT_RANGE};
+pub use json::{to_string_canonical, to_vec_canonical, CanonicalizationOptions};
 #[doc(inline)]
 #[cfg(feature = "signed")]
 pub use signed::Signed;

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -15,11 +15,17 @@ use serde::ser::Serializer;
 use serde::Serialize;
 use serde_json::Value;
 
+/// API to wrap an existing signed JSON value with it's canonical form.
 pub trait Wrap<V, U, T>
 where
     V: Serialize,
 {
+    /// Wraps an existing value, with no signatures and a default unsigned
+    /// section.
     fn wrap(value: V) -> Result<Signed<V, U, T>, Error>;
+
+    /// Wraps an existing value, with no signatures and a default unsigned
+    /// section.
     fn wrap_with_unsigned(value: V, unsigned: U) -> Result<Signed<V, U, T>, Error>;
 }
 
@@ -48,8 +54,6 @@ where
     V: Serialize,
     U: Default,
 {
-    /// Wraps an existing value, with no signatures and a default unsigned
-    /// section.
     fn wrap(value: V) -> Result<Signed<V, U, JsonStrict>, Error> {
         Ok(Signed {
             value: Canonical::<V, JsonStrict>::wrap(value)?,
@@ -58,8 +62,6 @@ where
         })
     }
 
-    /// Wraps an existing value, with no signatures and a default unsigned
-    /// section.
     fn wrap_with_unsigned(value: V, unsigned: U) -> Result<Signed<V, U, JsonStrict>, Error> {
         Ok(Signed {
             value: Canonical::<V, JsonStrict>::wrap(value)?,
@@ -74,8 +76,6 @@ where
     V: Serialize,
     U: Default,
 {
-    /// Wraps an existing value, with no signatures and a default unsigned
-    /// section.
     fn wrap(value: V) -> Result<Signed<V, U, JsonRelaxed>, Error> {
         Ok(Signed {
             value: Canonical::<V, JsonRelaxed>::wrap(value)?,
@@ -84,8 +84,6 @@ where
         })
     }
 
-    /// Wraps an existing value, with no signatures and a default unsigned
-    /// section.
     fn wrap_with_unsigned(value: V, unsigned: U) -> Result<Signed<V, U, JsonRelaxed>, Error> {
         Ok(Signed {
             value: Canonical::<V, JsonRelaxed>::wrap(value)?,


### PR DESCRIPTION
I looked at a few other ways of doing this flag, and nothing seemed great.
Using some kind of lazy_static which reads from an environment variable could work, but then there is no good way of unit testing the behaviour. And it would limit the library to either entirely choose strict or relaxed canonicalization settings.
Adding a crate feature to handle the flag could work. But then you are commiting the application to choose between strict or relaxed again.

The downside to this is there is no way to pass the flag into `deserialize`, so that is currently set to always use `strict` options.

This implementation will work for the rust federation reader, and will allow it to dynamically choose whether to use strict canonicaliztion enforcement.